### PR TITLE
Add the Moderate Members Permission

### DIFF
--- a/src/main/kotlin/com/sandrabot/sandra/utils/permissions.kt
+++ b/src/main/kotlin/com/sandrabot/sandra/utils/permissions.kt
@@ -77,5 +77,6 @@ fun findTranslationKey(permission: Permission) = when (permission) {
     Permission.NICKNAME_MANAGE -> "manage_nicknames"
     Permission.MANAGE_ROLES -> "manage_roles"
     Permission.MANAGE_PERMISSIONS -> "manage_permissions"
+    Permission.MODERATE_MEMBERS -> "moderate_members"
     else -> throw MissingTranslationException("Missing translation for permission $permission")
 }

--- a/src/main/resources/translations/en_US.json
+++ b/src/main/resources/translations/en_US.json
@@ -30,7 +30,8 @@
     "change_nickname": "Change Nickname",
     "manage_nicknames": "Manage Nicknames",
     "manage_roles": "Manage Roles",
-    "manage_permissions": "Manage Permissions"
+    "manage_permissions": "Manage Permissions",
+    "moderate_members": "Timeout Members",
   },
   "categories": {
     "custom": "Custom",


### PR DESCRIPTION
The `MODERATE_MEMBERS` permission went live on [JDA 5.00 Alpha 4](https://javadoc.io/doc/net.dv8tion/JDA/5.0.0-alpha.4/net/dv8tion/jda/api/Permission.html#MODERATE_MEMBERS) and Discord uses the permission to let members use the built-in timeout feature. I've added the permission to Sandra's translations (English) so the bot can make use of the feature and display it to users.

In the translation, the permission is titled "Timeout Members" since that is how it displays in the client and thus, how users would recognize the permission.
![image](https://user-images.githubusercontent.com/72234820/155762464-192e7831-d9c9-441c-beff-9e1ebd56866c.png)

The permission in Sandra would allow for commands such as **mute** and **warn** to use that permission when checking instead of `KICK_MEMBERS` or `BAN_MEMBERS`. 