### PR TITLE
feat: daily command

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,11 +41,11 @@ dependencies {
     implementation("io.ktor:ktor-server-status-pages")
     implementation("io.ktor:ktor-serialization-kotlinx-json")
 
-    implementation("net.dv8tion:JDA:5.0.0-beta.22")
+    implementation("net.dv8tion:JDA:5.0.0-beta.23")
     implementation("com.github.minndevelopment:jda-ktx:78dbf82")
 
-    implementation("ch.qos.logback:logback-classic:1.5.3")
-    implementation("io.sentry:sentry-logback:7.6.0")
+    implementation("ch.qos.logback:logback-classic:1.5.6")
+    implementation("io.sentry:sentry-logback:7.8.0")
     implementation("net.jodah:expiringmap:0.5.11")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")

--- a/src/main/kotlin/com/sandrabot/sandra/commands/fun/Toss.kt
+++ b/src/main/kotlin/com/sandrabot/sandra/commands/fun/Toss.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 Avery Carroll and Logan Devecka
+ * Copyright 2017-2024 Avery Carroll and Logan Devecka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ class Toss : Command() {
 
     override suspend fun execute(event: CommandEvent) {
 
-        val (emote, side) = if (Random.nextBoolean()) Emotes.SANDOLLAR to "heads" else Emotes.TAILS to "tails"
+        val (emote, side) = if (Random.nextBoolean()) Emotes.CASH to "heads" else Emotes.TAILS to "tails"
         event.replyEmote(event.get("reply", event.get(side)), emote).setEphemeral(true).queue()
 
     }

--- a/src/main/kotlin/com/sandrabot/sandra/commands/social/Cash.kt
+++ b/src/main/kotlin/com/sandrabot/sandra/commands/social/Cash.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Avery Carroll and Logan Devecka
+ * Copyright 2017-2024 Avery Carroll and Logan Devecka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,6 @@ class Cash : Command(arguments = "[user]") {
         // the user is formatted as a mention to provide a clickable link to their profile
         val reply = event.get(if (user == event.user) "self" else "other", user.asMention, cash)
         // to prevent mention spam, disable all mentions in the reply
-        event.replyEmote(reply, Emotes.SANDOLLAR).mention().await()
+        event.replyEmote(reply, Emotes.CASH).mention().await()
     }
 }

--- a/src/main/kotlin/com/sandrabot/sandra/commands/social/Daily.kt
+++ b/src/main/kotlin/com/sandrabot/sandra/commands/social/Daily.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2024 Avery Carroll and Logan Devecka
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.sandrabot.sandra.commands.social
+
+import com.sandrabot.sandra.constants.Emotes
+import com.sandrabot.sandra.entities.Command
+import com.sandrabot.sandra.events.CommandEvent
+import com.sandrabot.sandra.utils.canDaily
+import com.sandrabot.sandra.utils.computeDailyReward
+import com.sandrabot.sandra.utils.format
+import com.sandrabot.sandra.utils.updateDailyStreak
+import kotlin.time.Duration.Companion.seconds
+
+@Suppress("unused")
+class Daily : Command(arguments = "[user]") {
+
+    override suspend fun execute(event: CommandEvent) {
+
+        // users may only redeem dailies once every 20 hours, unless they're a developer
+        if (!event.userConfig.canDaily() && !event.isOwner) {
+            val nextDaily = event.userConfig.dailyLast + 72_000_000 // 20 hours
+            val remaining = ((nextDaily - System.currentTimeMillis()) / 1_000).seconds.format()
+            event.replyEmote(event.get("cooldown", remaining), Emotes.TIME).setEphemeral(true).queue()
+            return
+        }
+
+        // allow the user to donate their reward to another account
+        val targetUser = event.arguments.user() ?: event.user
+        // prevent bots from receiving dailies and creating data profiles
+        if (targetUser.isBot || targetUser.isSystem) {
+            event.replyError(event.get("no_bots")).setEphemeral(true).queue()
+            return
+        }
+
+        // update the user's daily streak and cooldown
+        event.userConfig.updateDailyStreak()
+        // calculate the daily reward based on the updated streak
+        val amount = event.userConfig.computeDailyReward()
+        // deposit the adjusted amount into the target user's account
+        event.sandra.config[targetUser].cash += amount
+
+        // todo implement streak progression tooltips
+
+        val context = if (event.user == targetUser) "self" else "other"
+        event.replyEmote(event.get(context, amount.format(), targetUser), Emotes.SANDOLLAR).queue()
+
+    }
+}

--- a/src/main/kotlin/com/sandrabot/sandra/commands/social/Daily.kt
+++ b/src/main/kotlin/com/sandrabot/sandra/commands/social/Daily.kt
@@ -56,7 +56,7 @@ class Daily : Command(arguments = "[user]") {
         // todo implement streak progression tooltips
 
         val context = if (event.user == targetUser) "self" else "other"
-        event.replyEmote(event.get(context, amount.format(), targetUser), Emotes.SANDOLLAR).queue()
+        event.replyEmote(event.get(context, amount.format(), targetUser), Emotes.CASH).queue()
 
     }
 }

--- a/src/main/kotlin/com/sandrabot/sandra/config/UserConfig.kt
+++ b/src/main/kotlin/com/sandrabot/sandra/config/UserConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 Avery Carroll and Logan Devecka
+ * Copyright 2017-2024 Avery Carroll and Logan Devecka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,11 @@ import kotlinx.serialization.Serializable
 class UserConfig(override val id: Long) : ExperienceConfig() {
 
     var cash: Long = 0
+
+    var dailyLast: Long = 0
+    var dailyStreak: Int = 0
+    var dailyLongestStreak: Int = 0
+
     var reputation: Long = 0
     var reputationLast: Long = 0
 

--- a/src/main/kotlin/com/sandrabot/sandra/constants/Emotes.kt
+++ b/src/main/kotlin/com/sandrabot/sandra/constants/Emotes.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 Avery Carroll and Logan Devecka
+ * Copyright 2017-2024 Avery Carroll and Logan Devecka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ object Emotes {
     const val ARROW_RIGHT = "<:arrowright:987904244071948308>"
     const val BAN = "<:ban:987920148017082379>"
     const val BIN = "<:bin:987946764361404416>"
+    const val CASH = "<:cash:988965262550257664>"
     const val CHAT = "<:chat:987950926545444864>"
     const val COMMANDS = "<:commands:987913791671005275>"
     const val CONFIG = "<:config:988525871986016367>"
@@ -51,7 +52,6 @@ object Emotes {
     const val RESET = "<:reset:987912473564835841>"
     const val RETURN = "<:return:987904285138378822>"
     const val REWIND = "<:rewind:987904324539674685>"
-    const val SANDOLLAR = "<:sandollar:988965262550257664>"
     const val SUBTRACT = "<:subtract:987904481876381696>"
     const val SUCCESS = "<:success:987905974364942356>"
     const val TAILS = "<:tails:988965283546931260>"

--- a/src/main/kotlin/com/sandrabot/sandra/entities/Category.kt
+++ b/src/main/kotlin/com/sandrabot/sandra/entities/Category.kt
@@ -24,7 +24,7 @@ enum class Category(val emote: String) {
     CUSTOM(Emotes.PATREON),
     ESSENTIAL(Emotes.PIN),
     FUN(Emotes.FUN),
-    GAME(Emotes.SANDOLLAR),
+    GAME(Emotes.CASH),
     MODERATION(Emotes.MOD),
     MUSIC(Emotes.MUSIC),
     OWNER(Emotes.CONFIG),

--- a/src/main/resources/content/english.json
+++ b/src/main/resources/content/english.json
@@ -100,8 +100,14 @@
       "description": "claim your daily allowance once every 20 hours",
       "cooldown": "slow your roll my guy, you still have another %1$s left on the clock",
       "no_bots": "oops, bot accounts aren't allowed to receive dailies. do you have anyone else in mind?",
-      "self": "yippee! you redeemed your daily reward of $%1$s sandollars",
-      "other": "that was very nice of you. $%1$s sandollars have been deposited into %2$s's account",
+      "self": "## %1$s yippee! you redeemed your daily reward of $%2$s",
+      "other": "## %1$s that's very kind. you sent your daily reward of $%2$s to %3$s",
+      "streak": {
+        "hint": "come back again in **20 hours** to start a streak and earn even more cash",
+        "started": "you've started a streak! claim your dailies **every 20 hours** to keep it going!",
+        "continued": "keep up the great work, your streak has reached day %1$s. come back tomorrow at %2$s to earn more!",
+        "ended": "sadly, you waited too long and your streak of %1$s was lost. your longest streak ever was %2$s days"
+      },
       "arguments": {
         "user": {
           "name": "user",

--- a/src/main/resources/content/english.json
+++ b/src/main/resources/content/english.json
@@ -95,6 +95,20 @@
       "command_title": "commands",
       "more_information": "use /help [command] for more info"
     },
+    "daily": {
+      "name": "daily",
+      "description": "claim your daily allowance once every 20 hours",
+      "cooldown": "slow your roll my guy, you still have another %1$s left on the clock",
+      "no_bots": "oops, bot accounts aren't allowed to receive dailies. do you have anyone else in mind?",
+      "self": "yippee! you redeemed your daily reward of $%1$s sandollars",
+      "other": "that was very nice of you. $%1$s sandollars have been deposited into %2$s's account",
+      "arguments": {
+        "user": {
+          "name": "user",
+          "description": "someone you'd like to donate your daily to"
+        }
+      }
+    },
     "dog": {
       "name": "dog",
       "description": "fetches a dog from the depths of the internet"


### PR DESCRIPTION
Implements the daily command into the bot. Users may use `/daily` once every 20 hours to claim their reward. If less than 24 hours have passed, users can start a streak. Otherwise, if more than a day has passed, the user will lose their streak.

The longer their streak becomes, the higher the reward.
The ever increasing reward is calculated as such:
```kotlin
fun UserConfig.computeDailyReward(): Long {
    val multiplier = 1.0 + (0.33 * dailyStreak)
    return (200 * multiplier).roundToLong()
}
```

This gives users an incentive to frequently interact with Sandra, at least once a day.

Additionally, the user's longest streak score is stored so that the user can compete with themselves, and potentially others, to maintain their current streaks.